### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Clone this repository and install the requirements for the script. For Debian us
 
     git clone https://github.com/unix121/i3wm-themer
     cd i3wm-themer/
-    sudo pip install -r requirements.txt
+    python3 -m venv myenv
+    source myenv/bin/activate
+    python3 -m pip install -r requirements.txt
 
 Install all the requirements from the 'What you will need' section.
 Either manually or use one of the scripts created for some distros:


### PR DESCRIPTION
Update the installation requirements.text because of the error

pip install -r requirements.txt
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.